### PR TITLE
add key prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Alternatively, if you already have a fully configured DynamoDB client object, yo
         var config = { featureStore: store, useLdd: true };
         var client = LaunchDarkly.init('YOUR SDK KEY', config);
 
+5. If the same DynamoDB table is being shared by SDK clients for different LaunchDarkly environments, set the `prefix` option to a different short string for each one to keep the keys from colliding:
+
+        var store = DynamoDBFeatureStore('YOUR TABLE NAME', { prefix: 'env1' });
+
 Caching behavior
 ----------------
 

--- a/dynamodb_helpers.js
+++ b/dynamodb_helpers.js
@@ -1,0 +1,49 @@
+
+function paginationHelper(params, executeFn, startKey) {
+  return new Promise(function(resolve, reject) {
+    if (startKey) {
+      params['ExclusiveStartKey'] = startKey;
+    }
+    executeFn(params, function(err, data) {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      if ('LastEvaluatedKey' in data) {
+        paginationHelper(params, executeFn, data['LastEvaluatedKey']).then(function (nextPageItems) {
+          resolve(data.Items.concat(nextPageItems));
+        });
+      } else {
+        resolve(data.Items);
+      }
+    });
+  });
+}
+
+function queryHelper(client, params, startKey) {
+  return paginationHelper(params, function(params, cb) { return client.query(params, cb); }, startKey);
+}
+
+function batchWrite(client, tableName, ops) {
+  var writePromises = [];
+  // BatchWrite can only accept 25 items at a time, so split up the writes into batches of 25.
+  for (var i = 0; i < ops.length; i += 25) {
+    var requestItems = {};
+    requestItems[tableName] = ops.slice(i, i+25);
+    writePromises.push(new Promise(function(resolve, reject) {
+      client.batchWrite({
+        RequestItems: requestItems
+      }, function(err) {
+        err ? reject(err) : resolve();
+      });
+    }));
+  }
+  return writePromises;
+}
+
+module.exports = {
+  batchWrite: batchWrite,
+  paginationHelper: paginationHelper,
+  queryHelper: queryHelper
+};

--- a/tests/dynamodb_feature_store-test.js
+++ b/tests/dynamodb_feature_store-test.js
@@ -1,4 +1,5 @@
 var DynamoDBFeatureStore = require('../dynamodb_feature_store');
+var helpers = require('../dynamodb_helpers');
 var testBase = require('ldclient-node/test/feature_store_test_base');
 var AWS = require('aws-sdk');
 
@@ -62,9 +63,8 @@ describe('DynamoDBFeatureStore', function() {
 
   function clearTable(done) {
     var client = new AWS.DynamoDB.DocumentClient();
-    var store = makeStore();
     var ops = [];
-    store.underlyingStore.paginationHelper({TableName: table}, function (params, cb) { client.scan(params, cb); })
+    helpers.paginationHelper({TableName: table}, function (params, cb) { client.scan(params, cb); })
       .then(function (items) {
         for (var i = 0; i < items.length; i++) {
           ops.push({
@@ -77,7 +77,7 @@ describe('DynamoDBFeatureStore', function() {
             }
           });
         }
-        Promise.all(store.underlyingStore.batchWrite(ops))
+        Promise.all(helpers.batchWrite(client, table, ops))
           .then(function() { done(); });
       });
   }


### PR DESCRIPTION
This adds the ability to prepend a string to every partition key, so multiple independent SDK clients can share the same table. This was always an available option for the Redis feature store, but the initial spec for the DynamoDB one didn't include it. It's already been added to the Go SDK.

This did require a bit of refactoring, mostly because the initial check of what's currently in the table before we overwrite it in Init is no longer a full table scan.