### PR TITLE
fix key prefix logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly Node.js SDK DynamoDB integration will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.1.2] - 2019-01-16
+### Fixed:
+- The prefix property added in 1.1.0 did not work correctly: data was written with prefixed keys, but was read with non-prefixed keys. This has been fixed.
+
 ## [1.1.1] - 2019-01-14
 ### Fixed:
 - Fixed a potential race condition that could occur if one process is reading a feature flag while another one is updating the entire data set.

--- a/dynamodb_feature_store.js
+++ b/dynamodb_feature_store.js
@@ -194,7 +194,7 @@ function dynamoDBFeatureStoreInternal(tableName, options) {
 
   function marshalItem(kind, item) {
     return {
-      namespace: kind.namespace,
+      namespace: namespaceForKind(kind),
       key: item.key,
       version: item.version,
       item: JSON.stringify(item)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-node-dynamodb-store",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "DynamoDB-backed feature store for the LaunchDarkly Node.js SDK",
   "main": "dynamodb_feature_store.js",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     "eslint-formatter-pretty": "1.3.0",
     "jest": "23.6.0",
     "jest-junit": "5.2.0",
-    "ldclient-node": ">= 5.7.0",
+    "ldclient-node": ">= 5.7.1",
     "typescript": "3.0.1"
   },
   "jest": {

--- a/tests/dynamodb_feature_store-test.js
+++ b/tests/dynamodb_feature_store-test.js
@@ -90,6 +90,10 @@ describe('DynamoDBFeatureStore', function() {
     return new DynamoDBFeatureStore(table, {cacheTTL: 0});
   }
 
+  function makeStoreWithPrefix(prefix) {
+    return new DynamoDBFeatureStore(table, {prefix: prefix, cacheTTL: 0});
+  }
+
   function makeStoreWithHook(hook) {
     var store = makeStore();
     store.underlyingStore.testUpdateHook = hook;
@@ -101,7 +105,7 @@ describe('DynamoDBFeatureStore', function() {
   });
 
   describe('uncached', function() {
-    testBase.baseFeatureStoreTests(makeStoreWithoutCache, clearTable, false);
+    testBase.baseFeatureStoreTests(makeStoreWithoutCache, clearTable, false, makeStoreWithPrefix);
   });
 
   testBase.concurrentModificationTests(makeStore, makeStoreWithHook);


### PR DESCRIPTION
This fixes a dumb mistake I made in adding the key prefix feature in 1.1.0; it didn't work because the prefix was only being used for writes, not for reads.

It also makes use of some extra unit test functionality added in ldclient-node 5.7.1 so that we are now actually testing that feature (as we now do for all feature stores).