### PR TITLE
fix broken init logic when there's a key prefix

### DIFF
--- a/dynamodb_feature_store.js
+++ b/dynamodb_feature_store.js
@@ -59,7 +59,7 @@ function dynamoDBFeatureStoreInternal(tableName, options) {
         }
       }
       cb(results);
-    }, function (err) {
+    }).catch(function (err) {
       logger.error('failed to get all ' + kind.namespace +  ': ' + err);
       cb(null);
     });
@@ -104,11 +104,12 @@ function dynamoDBFeatureStoreInternal(tableName, options) {
 
         var writePromises = helpers.batchWrite(dynamoDBClient, tableName, ops);
     
-        return Promise.all(writePromises).then(function() { cb && cb(); });
-      },
-      function (err) {
+        return Promise.all(writePromises);
+      })
+      .catch(function (err) {
         logger.error('failed to initialize: ' + err);
-      });
+      })
+      .then(function() { cb && cb(); });
   };
 
   store.upsertInternal = function(kind, item, cb) {

--- a/dynamodb_feature_store.js
+++ b/dynamodb_feature_store.js
@@ -77,10 +77,9 @@ function dynamoDBFeatureStoreInternal(tableName, options) {
         // Write all initial data (without version checks).
         var ops = [];
         allData.forEach(function(collection) {
-          var kindNamespace = collection.kind.namespace;
           collection.items.forEach(function(item) {
             var key = item.key;
-            delete existingNamespaceKeys[kindNamespace + '$' + key];
+            delete existingNamespaceKeys[namespaceForKind(collection.kind) + '$' + key];
             ops.push({ PutRequest: makePutRequest(collection.kind, item) });
           });
         });

--- a/dynamodb_feature_store.js
+++ b/dynamodb_feature_store.js
@@ -70,7 +70,7 @@ function dynamoDBFeatureStoreInternal(tableName, options) {
       .then(function(existingItems) {
         var existingNamespaceKeys = {};
         for (var i = 0; i < existingItems.length; i++) {
-          existingNamespaceKeys[makeNamespaceKey(existingItems[i])] = existingItems[i].version;
+          existingNamespaceKeys[makeNamespaceKey(existingItems[i])] = true;
         }
         delete existingNamespaceKeys[makeNamespaceKey(initializedToken())];
         
@@ -80,27 +80,18 @@ function dynamoDBFeatureStoreInternal(tableName, options) {
           collection.items.forEach(function(item) {
             var key = item.key;
             delete existingNamespaceKeys[namespaceForKind(collection.kind) + '$' + key];
-            ops.push({ PutRequest: makePutRequest(collection.kind, item) });
+            ops.push({ PutRequest: { Item: marshalItem(collection.kind, item) } });
           });
         });
 
         // Remove existing data that is not in the new list.
         for (var namespaceKey in existingNamespaceKeys) {
-          var version = existingNamespaceKeys[namespaceKey];
           var namespaceAndKey = namespaceKey.split('$');
-          ops.push({ DeleteRequest: {
-            TableName: tableName,
-            Key: {
-              namespace: namespaceAndKey[0],
-              key: namespaceAndKey[1]
-            },
-            ConditionExpression: 'attribute_not_exists(version) OR version < :new_version',
-            ExpressionAttributeValues: {':new_version': version }
-          }});
+          ops.push({ DeleteRequest: { Key: { namespace: namespaceAndKey[0], key: namespaceAndKey[1] } } });
         }
 
         // Always write the initialized token when we initialize.
-        ops.push({PutRequest: { TableName: tableName, Item: initializedToken() }});
+        ops.push({ PutRequest: { Item: initializedToken() } });
 
         var writePromises = helpers.batchWrite(dynamoDBClient, tableName, ops);
     
@@ -113,7 +104,7 @@ function dynamoDBFeatureStoreInternal(tableName, options) {
   };
 
   store.upsertInternal = function(kind, item, cb) {
-    var params = makePutRequest(kind, item);
+    var params = makeVersionedPutRequest(kind, item);
 
     // testUpdateHook is instrumentation, used only by the unit tests
     var prepare = store.testUpdateHook || function(prepareCb) { prepareCb(); };
@@ -213,7 +204,7 @@ function dynamoDBFeatureStoreInternal(tableName, options) {
     return null;
   }
 
-  function makePutRequest(kind, item) {
+  function makeVersionedPutRequest(kind, item) {
     return {
       TableName: tableName,
       Item: marshalItem(kind, item),

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
     "env": {
         "node": true,
         "es6": true,
-        "jasmine": true
+        "jasmine": true,
+        "jest": true
     },
 };

--- a/tests/dynamodb_feature_store-test.js
+++ b/tests/dynamodb_feature_store-test.js
@@ -133,7 +133,7 @@ describe('DynamoDBFeatureStore', function() {
     });
 
     it('error from query in init', done => {
-      var data = { features: { flag: { key: "flag", version: 1 } } };
+      var data = { features: { flag: { key: 'flag', version: 1 } } };
       client.query = (params, cb) => cb(err);
       store.init(data, function() {
         expect(logger.error).toHaveBeenCalled();
@@ -142,7 +142,7 @@ describe('DynamoDBFeatureStore', function() {
     });
 
     it('error from batchWrite in init', done => {
-      var data = { features: { flag: { key: "flag", version: 1 } } };
+      var data = { features: { flag: { key: 'flag', version: 1 } } };
       client.query = (params, cb) => cb(null, { Items: [] });
       client.batchWrite = (params, cb) => cb(err);
       store.init(data, function() {

--- a/tests/dynamodb_feature_store-test.js
+++ b/tests/dynamodb_feature_store-test.js
@@ -104,6 +104,10 @@ describe('DynamoDBFeatureStore', function() {
     return new DynamoDBFeatureStore(table, {prefix: prefix, cacheTTL: 0});
   }
 
+  function makeStoreWithDefaultPrefix() {
+    return makeStoreWithPrefix('test');
+  }
+
   function makeStoreWithHook(hook) {
     var store = makeStore();
     store.underlyingStore.testUpdateHook = hook;
@@ -116,6 +120,12 @@ describe('DynamoDBFeatureStore', function() {
 
   describe('uncached', function() {
     testBase.baseFeatureStoreTests(makeStoreWithoutCache, clearTable, false, makeStoreWithPrefix);
+  });
+
+  // We run the test suite again here because in the DynamoDB implementation, the prefix is entirely
+  // omitted by default, so we want to make sure all the logic is correct with or without one.
+  describe('uncached with prefix', function() {
+    testBase.baseFeatureStoreTests(makeStoreWithDefaultPrefix, clearTable, false);
   });
 
   testBase.concurrentModificationTests(makeStore, makeStoreWithHook);


### PR DESCRIPTION
Unfortunately, there was _yet another_ code path that I missed when I added the key prefix feature. The effect was a bit subtle:

1. IF you have set a key prefix,
2. AND you store a bunch of data with `init()`,
3. AND THEN you call `init()` again with a data set that includes at least one of the same items,
4. then the second `init()` will fail, with the error "list of item keys contains duplicates"—and also you will get an "unhandled promise rejection", which is bad.

Unfortunately, the shared unit tests for feature stores didn't test this specific scenario. I can add that to the test suite, but it's pretty specific and not really the kind of thing we could've reasonably anticipated, so it just makes me wonder what other scenarios we're missing. However, I have added some tests here to at least verify that if a database error happens, we handle it correctly and don't end up with an unhandled rejection.

(Edit: I also updated the unit tests so the full test suite is run both with and without a database prefix. Previously, it was only run without a prefix, except for a single test. I feel fairly confident in the coverage now.)